### PR TITLE
Update MaxBundleVersion to "*"

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -28,7 +28,7 @@
 			<key>BundleIdentifier</key>
 			<string>com.apple.Terminal</string>
 			<key>MaxBundleVersion</key>
-			<string>309</string>
+			<string>*</string>
 			<key>MinBundleVersion</key>
 			<string>237</string>
 		</dict>


### PR DESCRIPTION
A package built with this works with newer Terminal.app.

This is one of u-minor's patches.
https://github.com/u-minor/terminalcopyonselect/commit/2c37751f52bf078d747d144d4349527626871b45